### PR TITLE
make SINGULAR_DEEPLINK_KEY constant public

### DIFF
--- a/mParticle-Singular/MPKitSingular.h
+++ b/mParticle-Singular/MPKitSingular.h
@@ -8,6 +8,8 @@
 #import "mParticle.h"
 #endif
 
+#define SINGULAR_DEEPLINK_KEY @"SingularDeepLink"
+
 @interface MPKitSingular : NSObject <MPKitProtocol>
 
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;

--- a/mParticle-Singular/MPKitSingular.m
+++ b/mParticle-Singular/MPKitSingular.m
@@ -23,7 +23,6 @@ NSUInteger MPKitInstanceSingularTemp = 119;
 #define TOTAL_PRODUCT_AMOUNT @"Total Product Amount"
 #define USER_GENDER_MALE @"m"
 #define USER_GENDER_FEMALE @"f"
-#define SINGULAR_DEEPLINK_KEY @"SingularDeepLink"
 
 NSString *appKey;
 NSString *secret;


### PR DESCRIPTION
This change moves the `SINGULAR_DEEPLINK_KEY` constant to the header file so it can be publicly referenced.

The constant needed for referencing the Singular deep link key is [defined in the implementation file](https://github.com/mparticle-integrations/mparticle-apple-integration-singular/blob/master/mParticle-Singular/MPKitSingular.m#L26) and cannot be accessed outside of this file making it impossible to integrate this kit according to the [documentation](http://docs.mparticle.com/integrations/singular/event/#embedded-kit-integration)

```
[[MParticle sharedInstance] kitInstance:@(MPKitInstanceSingular) completionHandler:^(id  _Nullable kitInstance) {
        [[MParticle sharedInstance] checkForDeferredDeepLinkWithCompletionHandler:^(NSDictionary<NSString *,NSString *> * _Nullable params, NSError * _Nullable error) {
            //check for SINGULAR_DEEPLINK_KEY

            // can't reference SINGULAR_DEEPLINK_KEY since it is defined in 
            // the MPKitSingular.m file
        }];
}];
```

Ideally this constant should be defined as `NSString * const` types in order to be consistent with the other mParticle Kit APIs such as [Button](https://github.com/mparticle-integrations/mparticle-apple-integration-button/blob/master/mParticle-Button/MPKitButton.h#L28).