### PR TITLE
feat: Update Singular SDK to Version 12.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
       .package(url: "https://github.com/mParticle/mparticle-apple-sdk",
                .upToNextMajor(from: "8.0.0")),
       .package(url: "https://github.com/singular-labs/Singular-iOS-SDK",
-               .upToNextMajor(from: "11.0.0")),
+               .upToNextMajor(from: "12.0.0")),
     ],
     targets: [
         .target(

--- a/mParticle-Singular.podspec
+++ b/mParticle-Singular.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'Sources/mParticle-Singular/**/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'Singular-SDK'
+    s.ios.dependency 'Singular-SDK', '~> 12.0'
 
 end


### PR DESCRIPTION
## Summary
 - Updated to major version 12 of the Singular SDK

 ## Testing Plan
 - Tested on sample and confirmed data being received in Singular
 
<img width="1127" alt="Screenshot 2023-12-12 at 10 27 58 AM" src="https://github.com/mparticle-integrations/mparticle-apple-integration-singular/assets/33703490/f01ff793-e716-4a88-9609-b2f70dc75edb">


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5874
