### PR TITLE
feat: Improve Privacy Manifest support for iOS 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
             dependencies: [
                .product(name: "mParticle-Apple-SDK", package: "mparticle-apple-sdk"),
                .product(name: "Singular", package: "Singular-iOS-SDK"),
-            ]
+            ],
+            resources: [.process("PrivacyInfo.xcprivacy")]
         )
     ]
 )

--- a/Sources/mParticle-Singular/PrivacyInfo.xcprivacy
+++ b/Sources/mParticle-Singular/PrivacyInfo.xcprivacy
@@ -2,17 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyTracking</key>
-    <false/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array/>
-    <key>NSPrivacyCollectedDataTypes</key>
-    <array>
-        <dict/>
-    </array>
-    <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-        <dict/>
-    </array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
 </dict>
 </plist>

--- a/mParticle-Singular.podspec
+++ b/mParticle-Singular.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 	s.static_framework = true
     s.ios.deployment_target = "12.0"
     s.ios.source_files      = 'Sources/mParticle-Singular/**/*.{h,m,mm}'
+    s.ios.resource_bundles  = { 'mParticle-Singular-Privacy' => ['Sources/mParticle-Singular/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.dependency 'Singular-SDK', '~> 12.4'
 


### PR DESCRIPTION
 ## Summary
 - Fix parsing issue due to empty dict
 - Ensure manifest is included by package managers

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed in test apps

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6413